### PR TITLE
adds search resource

### DIFF
--- a/lib/infoblox/resource/search.rb
+++ b/lib/infoblox/resource/search.rb
@@ -5,12 +5,19 @@ module Infoblox
     # does not return objects not implemented in this library
     def self.find(connection,params)
       response = JSON.parse(connection.get(resource_uri,params).body)
-      response.map { |jobj| klass = resource_map[jobj["_ref"].split("/").first]; klass.nil? ? nil: klass.new(jobj) }.compact
+      response.map do |jobj| 
+        klass = resource_map[jobj["_ref"].split("/").first]
+        if klass.nil?
+          nil
+        else
+          klass.new(jobj.merge({:connection => connection}))
+        end
+      end.compact
     end
     
     # @private 
     def self.resource_map
-      resource_classes = Infoblox.constants.collect do |c|
+      resource_classes = Infoblox.constants.map do |c|
                            Infoblox.const_get(c)
                          end.select do |c|
                            c.is_a?(Class) && c < Infoblox::Resource


### PR DESCRIPTION
So I'm still learning ruby. This implements the Search resource, which really isn't a resource. It takes two params, (search_string and objtype) and no _return_fields. I added the resource map of all resources currently implemented by this library so that when the search returns a bunch of JSON, I can return a bunch of ruby objects to the user.

The big thing is that if the search returns an object that this library doesn't have, like say an RRSIG record or something, that just gets dropped from the result. I feel like this is non-intuitive and may lead someone to hate me down the road when they use this not realizing its limitations. I'm doing this as part of my implementation a cli using the GLI gem. 
