### PR TITLE
Fix remote attribute hash for host

### DIFF
--- a/lib/infoblox/resource/host.rb
+++ b/lib/infoblox/resource/host.rb
@@ -21,7 +21,7 @@ module Infoblox
 
     def remote_attribute_hash(write=false, post=false)
       super.tap do |hsh|
-        hsh[:ipv4addrs] = ipv4addrs.map{|i| {:ipv4addr => i.ipv4addr}}
+        hsh[:ipv4addrs] = ipv4addrs.map{|ipv4obj| Hash[ipv4obj.class.remote_attrs.map { |attrib| [attrib, ipv4obj.send(attrib)] unless ipv4obj.send(attrib).nil? }] }
       end
     end
   end


### PR DESCRIPTION
I am completely lost here. The host object taps the remote_attribute_hash function so it can convert its host_ipv4addr into a hash. The problem is the only field it recognizes from that is ipv4addr, ignoring things like mac and configure_for_dhcp. 

Would this be better as a method on Resource that makes an object spit out its set attributes? I have a bad feeling that due to infoblox's ..skill.. that the state relationship between Host and HostIpv4 that you're molding to here is not going to line up nicely. 
