### PR TITLE
Added nextserver and use_nextserver to remote_attr_accesor in host_ip…

### DIFF
--- a/lib/infoblox/resource/host_ipv4addr.rb
+++ b/lib/infoblox/resource/host_ipv4addr.rb
@@ -3,7 +3,9 @@ module Infoblox
     remote_attr_accessor :configure_for_dhcp, 
                          :ipv4addr, 
                          :mac,
-                         :network
+                         :network,
+                         :nextserver,
+                         :use_nextserver
                          
     remote_post_accessor :host
     

--- a/spec/host_ipv4addr_spec.rb
+++ b/spec/host_ipv4addr_spec.rb
@@ -5,7 +5,7 @@ describe Infoblox::HostIpv4addr do
     expected = [:host]
     expect(Infoblox::HostIpv4addr.remote_post_attrs).to eq(expected)
 
-    expected = [:network, :ipv4addr, :configure_for_dhcp, :mac].sort
+    expected = [:network, :ipv4addr, :configure_for_dhcp, :mac, :nextserver, :use_nextserver].sort
     expect(Infoblox::HostIpv4addr.remote_attrs.sort).to eq(expected)
   end
 end  


### PR DESCRIPTION
…v4addr since I needed this for TFTP integration with Foreman