### PR TITLE
Add attributes required for different record types

### DIFF
--- a/lib/infoblox/resource/arecord.rb
+++ b/lib/infoblox/resource/arecord.rb
@@ -1,11 +1,14 @@
 module Infoblox
   class Arecord < Resource
-    remote_attr_accessor :extattrs,
-                         :extensible_attributes, 
-                         :ipv4addr, 
+    remote_attr_accessor :comment,
+                         :disable,
+                         :extattrs,
+                         :extensible_attributes,
+                         :ipv4addr,
+                         :name,
                          :ttl,
-                         :view, 
-                         :name
+                         :view,
+                         :zone
 
     wapi_object "record:a"
   end

--- a/lib/infoblox/resource/cname.rb
+++ b/lib/infoblox/resource/cname.rb
@@ -2,10 +2,13 @@ module Infoblox
   class Cname < Resource
     remote_attr_accessor :canonical, 
                          :comment,
+                         :disable,
                          :extattrs,
                          :extensible_attributes, 
                          :name, 
-                         :view
+                         :view,
+                         :zone
+
 
     wapi_object "record:cname"
   end

--- a/lib/infoblox/resource/fixedaddress.rb
+++ b/lib/infoblox/resource/fixedaddress.rb
@@ -2,11 +2,14 @@ module Infoblox
   # minimum WAPI version: 1.1
   class Fixedaddress < Resource
     remote_attr_accessor :extattrs,
-                         :ipv4addr, 
-                         :mac, 
-                         :name, 
+                         :ipv4addr,
+                         :mac,
+                         :name,
+                         :network,
+                         :network_view,
                          :options,
-                         :match_client
+                         :match_client,
+                         :comment
 
     wapi_object "fixedaddress"
   end

--- a/lib/infoblox/resource/host.rb
+++ b/lib/infoblox/resource/host.rb
@@ -1,12 +1,15 @@
 module Infoblox
   class Host < Resource
-    remote_attr_accessor :extattrs,
-                         :extensible_attributes, 
-                         :view, 
-                         :aliases,
-                         :configure_for_dns, 
-                         :ipv4addrs, 
-                         :name
+    remote_attr_accessor :aliases,
+                         :comment,
+                         :configure_for_dns,
+                         :disable,
+                         :extattrs,
+                         :extensible_attributes,
+                         :ipv4addrs,
+                         :name,
+                         :view,
+                         :zone
 
     wapi_object "record:host"
 

--- a/lib/infoblox/resource/network.rb
+++ b/lib/infoblox/resource/network.rb
@@ -1,8 +1,10 @@
 module Infoblox 
   class Network < Resource
-    remote_attr_accessor :extattrs,
+    remote_attr_accessor :comment,
+                         :extattrs,
                          :extensible_attributes, 
                          :network
+                         
 
     remote_post_accessor :auto_create_reversezone
     

--- a/lib/infoblox/resource/ptr.rb
+++ b/lib/infoblox/resource/ptr.rb
@@ -1,11 +1,15 @@
 module Infoblox
   class Ptr < Resource
-    remote_attr_accessor :extattrs,
-                         :extensible_attributes, 
-                         :view, 
-                         :ipv4addr, 
+    remote_attr_accessor :comment,
+                         :disable,
+                         :ipv4addr,
+                         :ipv6addr,
                          :name, 
-                         :ptrdname 
+                         :ptrdname,
+                         :extattrs,
+                         :extensible_attributes,
+                         :view, 
+                         :zone
 
     wapi_object "record:ptr"
   end


### PR DESCRIPTION
@unclebilly 
I have added some optional attributes for A, AAAA, PTR, CNAME, host, fixedaddress and network record types.
Please review and merge if there are no issues.