### PR TITLE
Change Ipv4address behaviour to use remote_attr_accessor

### DIFF
--- a/lib/infoblox/resource/ipv4address.rb
+++ b/lib/infoblox/resource/ipv4address.rb
@@ -1,18 +1,18 @@
 module Infoblox
   class Ipv4address < Resource
-    attr_accessor :dhcp_client_identifier, 
-                  :ip_address, 
-                  :is_conflict, 
-                  :lease_state, 
-                  :mac_address, 
-                  :names, 
-                  :network, 
-                  :network_view, 
-                  :objects, 
-                  :status, 
-                  :types, 
-                  :usage, 
-                  :username
+    remote_attr_accessor :dhcp_client_identifier, 
+                         :ip_address, 
+                         :is_conflict, 
+                         :lease_state, 
+                         :mac_address, 
+                         :names, 
+                         :network, 
+                         :network_view, 
+                         :objects, 
+                         :status, 
+                         :types, 
+                         :usage, 
+                         :username
     
     wapi_object "ipv4address"
 


### PR DESCRIPTION
I'm not sure if you made this on purpose but I would like to return values by default