### PR TITLE
Make ipv6addr fields depend on WAPI version

### DIFF
--- a/lib/infoblox/resource/aaaa_record.rb
+++ b/lib/infoblox/resource/aaaa_record.rb
@@ -11,8 +11,9 @@ module Infoblox
                          :use_ttl, 
                          :view
     
-    remote_attr_reader :dns_name, 
-                       :zone
+    remote_attr_reader :zone
+
+    remote_attr_reader :dns_name if Infoblox::Resource.wapi_object.to_f >= 1.1
 
     wapi_object "record:aaaa"
   end

--- a/lib/infoblox/resource/host.rb
+++ b/lib/infoblox/resource/host.rb
@@ -10,7 +10,7 @@ module Infoblox
                          :name,
                          :view
 
-    remote_attr_accessor :ipv6addrs if ENV['WAPI_VERSION'].to_f >= 1.1
+    remote_attr_accessor :ipv6addrs if Infoblox::Resource.wapi_object.to_f >= 1.1
 
     remote_attr_reader :zone
 

--- a/lib/infoblox/resource/host.rb
+++ b/lib/infoblox/resource/host.rb
@@ -10,6 +10,8 @@ module Infoblox
                          :name,
                          :view
 
+    remote_attr_accessor :ipv6addrs if ENV['WAPI_VERSION'].to_f >= 1.1
+
     remote_attr_reader :zone
 
     wapi_object "record:host"

--- a/lib/infoblox/resource/ptr.rb
+++ b/lib/infoblox/resource/ptr.rb
@@ -3,12 +3,13 @@ module Infoblox
     remote_attr_accessor :comment,
                          :disable,
                          :ipv4addr,
-                         :ipv6addr,
                          :name, 
                          :ptrdname,
                          :extattrs,
                          :extensible_attributes,
                          :view
+
+    remote_attr_accessor :ipv6addr if ENV['WAPI_VERSION'].to_f >= 1.1
     
     remote_attr_reader :zone
 

--- a/lib/infoblox/resource/ptr.rb
+++ b/lib/infoblox/resource/ptr.rb
@@ -9,7 +9,7 @@ module Infoblox
                          :extensible_attributes,
                          :view
 
-    remote_attr_accessor :ipv6addr if ENV['WAPI_VERSION'].to_f >= 1.1
+    remote_attr_accessor :ipv6addr if Infoblox::Resource.wapi_object.to_f >= 1.1
     
     remote_attr_reader :zone
 


### PR DESCRIPTION
The ptr record api only accepts ipv6addr in versions >= 1.1. The host object also has the field ipv6addrs only for api versions higher that 1.1. The field is only added, and therefore passed as return fields, when the api version is the appropriate. This commit fixes #35 