### PR TITLE
update ptr.rb to add 'ttl' attribute to fix issue#38

### DIFF
--- a/lib/infoblox/resource/ptr.rb
+++ b/lib/infoblox/resource/ptr.rb
@@ -6,6 +6,7 @@ module Infoblox
                          :ipv6addr,
                          :name, 
                          :ptrdname,
+                         :ttl,
                          :extattrs,
                          :extensible_attributes,
                          :view


### PR DESCRIPTION
Occasionally people need to update ttl for PTR records, just as they need to do so for A records.