### PR TITLE
Add Roaming host entry for Infoblox

### DIFF
--- a/lib/infoblox/resource/roaminghost.rb
+++ b/lib/infoblox/resource/roaminghost.rb
@@ -1,0 +1,18 @@
+module Infoblox
+  # minimum WAPI version: 1.1
+  class RoamingHost < Resource
+    remote_attr_accessor :extattrs,
+                         :mac,
+                         :bootfile,
+                         :use_bootfile,
+                         :nextserver,
+                         :use_nextserver,
+                         :name,
+                         :network_view,
+                         :options,
+                         :match_client,
+                         :comment
+
+    wapi_object 'roaminghost'
+  end
+end


### PR DESCRIPTION
This allows specifying DHCP options for MAC addresses without explicitly
locking them to a fixed address.