### PR TITLE
Added timeout connection option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ rvm:
   - 2.1.10
   - 1.9.3
   - jruby-9.2.7.0
-  - 1.8.7
 # https://docs.travis-ci.com/user/languages/ruby/
 # https://bundler.io/blog/2019/01/04/an-update-on-the-bundler-2-release.html
 before_install:

--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ You can supply a logger to get debugging information:
 
     connection = Infoblox::Connection.new(username: '', password: '', host: '', logger: Logger.new(STDOUT))
 
+It is possible to set timeout, read and write timeout:
+
+    connection = Infoblox::Connection.new(username: '', password: '', host: '', timeout: 120)
+
 ## Reading
 Each resource class implements `.all`, `.find`, and `#get`.   
 
@@ -196,7 +200,9 @@ The default version is 2.0.
 
 ## Ruby Version Compatibility
 
-This gem is tested against Ruby versions 1.8.7, 1.9.3, 2.1.6, JRuby-head, and JRuby in 1.9 mode.
+This gem is tested against Ruby versions 1.9.3, 2.1.6, JRuby-head, and JRuby in 1.9 mode.
+
+The last compatible version with Ruby 1.8.x is 2.0.5.
 
 ## Development / testing
 

--- a/lib/infoblox/connection.rb
+++ b/lib/infoblox/connection.rb
@@ -10,7 +10,8 @@ module Infoblox
                   :logger,
                   :password,
                   :ssl_opts,
-                  :username
+                  :username,
+                  :timeout
 
     def get(href, params={})
       wrap do
@@ -48,10 +49,14 @@ module Infoblox
       self.host     = opts[:host]
       self.logger   = opts[:logger]
       self.ssl_opts = opts[:ssl_opts] || {}
+      self.timeout  = opts[:timeout] || 60
     end
 
     def connection
-      @connection ||= Faraday.new(:url => self.host, :ssl => self.ssl_opts) do |faraday|
+      @connection ||= Faraday.new(
+        :request => {:timeout => self.timeout, :open_timeout => self.timeout},
+        :url => self.host,
+        :ssl => self.ssl_opts) do |faraday|
         faraday.use Faraday::Response::Logger, logger if logger
         faraday.request :json
         faraday.basic_auth(self.username, self.password)

--- a/spec/integration/connection_timeout_spec.rb
+++ b/spec/integration/connection_timeout_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+require 'socket'
+
+describe 'Infoblox::Connection' do
+  it "should timeout in defined time" do
+    begin
+      server = TCPServer.new('localhost', 8813)
+      host = 'localhost:8813'
+      conn_params = {
+        :host => host,
+        :timeout => 4
+      }
+      uri = "/wapi/v1.0"
+
+      ic = Infoblox::Connection.new(conn_params)
+      start = Time.now
+      if RUBY_VERSION < "2.0"
+        # old pinned version of faraday gem throws a different exception
+        expect { ic.get(uri) }.to raise_error(Faraday::TimeoutError)
+      else
+        expect { ic.get(uri) }.to raise_error(Faraday::ConnectionFailed)
+      end
+      finish = Time.now
+      # this should take approx. 4 seconds but let's be safe
+      expect(finish - start).to be_between(3, 55)
+    ensure
+      server.close
+    end
+  end
+end


### PR DESCRIPTION
Hello there! This adds timeout option parameter, to make it less verbose I propose only to add unified timeout parameter to set both timeouts at once:

* open timeout
* read timeout

Unfortunately write timeout (Ruby 2.6+ for Net::HTTP) is not supported at all. I only tested this with Net::HTTP honestly.

Edit: Actually also write timeout is set for Net::HTTP: https://github.com/lostisland/faraday/blob/d4f062a56b201af97ac1c0d3b9bcc0487b5dc408/lib/faraday/adapter/net_http.rb#L167-L183 and it looks like the two Faraday timeouts are "mapped" to multiple timeouts in various implementations so I think providing those in one global timeout should not be an issue.